### PR TITLE
Fix trackTruthParticleIndex bug in case of invalid particle barcode

### DIFF
--- a/src/MLTreeMaker.cxx
+++ b/src/MLTreeMaker.cxx
@@ -837,14 +837,21 @@ StatusCode MLTreeMaker::execute()
           linkedTruthParticle = *truthLink;
       }
 
-      //get truth particle barcode for track
+      //get index of truth particle associated with track via barcode map
+      int truthParticleIndex = -1;
       if (linkedTruthParticle){
         int barcode = linkedTruthParticle->barcode();
-        unsigned int truthParticleIndex = truthBarcodeMap[barcode];
-        m_trackTruthParticleIndex.push_back(truthParticleIndex);
-        truthVisibleCalHitCaloEnergyMap[barcode] = m_trackVisibleCalHitCaloEnergy[m_nTrack];
-        truthFullCalHitCaloEnergyMap[barcode] = m_trackFullCalHitCaloEnergy[m_nTrack];
+
+        //check if the barcode is in the map
+        const auto mapItr = truthBarcodeMap.find(barcode);
+        if (mapItr != truthBarcodeMap.end())
+        {
+          truthParticleIndex = truthBarcodeMap[barcode];
+          truthVisibleCalHitCaloEnergyMap[barcode] = m_trackVisibleCalHitCaloEnergy[m_nTrack];
+          truthFullCalHitCaloEnergyMap[barcode] = m_trackFullCalHitCaloEnergy[m_nTrack];
+        }
       }
+      m_trackTruthParticleIndex.push_back(truthParticleIndex);
 
       if (mapTrackSubtractedEnergy.find(track) != mapTrackSubtractedEnergy.end()){
         m_trackSubtractedCaloEnergy.push_back(mapTrackSubtractedEnergy[track]);	

--- a/src/MLTreeMaker.h
+++ b/src/MLTreeMaker.h
@@ -197,7 +197,7 @@ private:
   std::vector<float> m_trackEta;
   std::vector<float> m_trackPhi;
   //index of matched truth particle in m_truthPart* vectors
-  std::vector<unsigned int> m_trackTruthParticleIndex;
+  std::vector<int> m_trackTruthParticleIndex;
   //sum of visible calibration hit energy of this tracks
   //truth particle found in all topoclusters
   std::vector<float> m_trackVisibleCalHitCaloEnergy;


### PR DESCRIPTION
Now writing -1 to trackTruthParticleIndex in case particle barcode associated with track not valid (i.e. is not a key in the `truthBarcodeMap`).
Previously these cases led to potentially multiple instances of 0 being "retrieved" as a default value from the map.
Storing -1 required changing type of `m_trackTruthParticleIndex` from `unsigned int` to `int`